### PR TITLE
忽略Zone.Identifier文件类型的追踪

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.bcf
 *.toc
 *.synctex.gz
+*.Zone.Identifier


### PR DESCRIPTION
Signed-off-by: KenWong <xinxijishuwyq@gmail.com>
Zone.Identifier类型可能在Windows包括wsl下被生成